### PR TITLE
Write Unit Tests

### DIFF
--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -12,6 +12,8 @@ import {IERC20RootVaultGovernance} from "./interfaces/Mellow/IERC20RootVaultGove
 import "./utils/Mellow/ExceptionsLibrary.sol";
 import "./utils/Mellow/CommonLibrary.sol";
 import "./utils/Mellow/FullMath.sol";
+import "forge-std/console.sol";
+
 
 /// @title StrategyMellow-Gearbox_wETH: Yearn strategy for Mellow Fearless Gearboxstrategy
 /// @author @steve0xp && @0xValJohn
@@ -117,13 +119,22 @@ contract Strategy is BaseStrategy {
 
             (uint256[] memory minTvl,) = gearboxRootVault.tvl();
 
+            uint256 LP_CHECK_totalSupplyTEST = gearboxRootVault.totalSupply();
+            uint256 LP_CHECK_totalLpTokensWaitingWithdrawal = gearboxRootVault.totalLpTokensWaitingWithdrawal();
+            uint256 LP_CHECK_chargeFees = _chargeFees(thisNFT, minTvl[0], gearboxRootVault.totalSupply());
+
+        console.log("MARKER #1 CHECKING VARS VALUES: LP_CHECK_totalSupplyTEST: %s, LP_CHECK_chargeFees: %s, LP_CHECK_totalLpTokensWaitingWithdrawal: %s", LP_CHECK_totalSupplyTEST, LP_CHECK_totalLpTokensWaitingWithdrawal, LP_CHECK_chargeFees);
+
             uint256 lpSupply = (
                 gearboxRootVault.totalSupply() - gearboxRootVault.totalLpTokensWaitingWithdrawal()
-                    - _chargeFees(thisNFT, minTvl[0], gearboxRootVault.totalSupply())
+                    + LP_CHECK_chargeFees
             );
 
             uint256[] memory totalWantCapacityRemaining = new uint256[](1);
 
+            console.log("MARKER #2 CHECKING VARS VALUES: minTVL: %s, tokenLimit(amount able to be invested in mellow vault): %s, lpSupply: %s", minTvl[0], params.tokenLimit, lpSupply);
+
+            // TODO - BELOW IS THE LOC THAT IS CAUSING UNDERFLOW ERRORS
             totalWantCapacityRemaining[0] = (minTvl[0] * ((params.tokenLimit - lpSupply) * 1e18 / lpSupply)) / 1e18;
 
             require(totalWantCapacityRemaining[0] == 0, "Vault want capacity at max");

--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -145,7 +145,7 @@ contract Strategy is BaseStrategy {
             // @todo - BELOW IS THE LOC THAT IS CAUSING UNDERFLOW ERRORS
             totalWantCapacityRemaining[0] = (minTvl[0] * ((params.tokenLimit - lpSupply) * 1e18 / lpSupply)) / 1e18;
 
-            require(totalWantCapacityRemaining[0] == 0, "Vault want capacity at max");
+            require(lpSupply < totalWantCapacityRemaining[0], "Vault want capacity at max"); // @todo check if a revert is okay with yearn strategy harvest() sequences
 
             if (totalWantCapacityRemaining[0] > _amountToInvest[0]) {
                 gearboxRootVault.deposit(_amountToInvest, _minLpToMint, ""); // @todo investigate vaultOptions

--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -142,7 +142,7 @@ contract Strategy is BaseStrategy {
                 lpSupply
             );
 
-            // TODO - BELOW IS THE LOC THAT IS CAUSING UNDERFLOW ERRORS
+            // @todo - BELOW IS THE LOC THAT IS CAUSING UNDERFLOW ERRORS
             totalWantCapacityRemaining[0] = (minTvl[0] * ((params.tokenLimit - lpSupply) * 1e18 / lpSupply)) / 1e18;
 
             require(totalWantCapacityRemaining[0] == 0, "Vault want capacity at max");

--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -14,7 +14,6 @@ import "./utils/Mellow/CommonLibrary.sol";
 import "./utils/Mellow/FullMath.sol";
 import "forge-std/console.sol";
 
-
 /// @title StrategyMellow-Gearbox_wETH: Yearn strategy for Mellow Fearless Gearboxstrategy
 /// @author @steve0xp && @0xValJohn
 
@@ -123,16 +122,25 @@ contract Strategy is BaseStrategy {
             uint256 LP_CHECK_totalLpTokensWaitingWithdrawal = gearboxRootVault.totalLpTokensWaitingWithdrawal();
             uint256 LP_CHECK_chargeFees = _chargeFees(thisNFT, minTvl[0], gearboxRootVault.totalSupply());
 
-        console.log("MARKER #1 CHECKING VARS VALUES: LP_CHECK_totalSupplyTEST: %s, LP_CHECK_chargeFees: %s, LP_CHECK_totalLpTokensWaitingWithdrawal: %s", LP_CHECK_totalSupplyTEST, LP_CHECK_totalLpTokensWaitingWithdrawal, LP_CHECK_chargeFees);
+            console.log(
+                "MARKER #1 CHECKING VARS VALUES: LP_CHECK_totalSupplyTEST: %s, LP_CHECK_chargeFees: %s, LP_CHECK_totalLpTokensWaitingWithdrawal: %s",
+                LP_CHECK_totalSupplyTEST,
+                LP_CHECK_totalLpTokensWaitingWithdrawal,
+                LP_CHECK_chargeFees
+            );
 
             uint256 lpSupply = (
-                gearboxRootVault.totalSupply() - gearboxRootVault.totalLpTokensWaitingWithdrawal()
-                    + LP_CHECK_chargeFees
+                gearboxRootVault.totalSupply() - gearboxRootVault.totalLpTokensWaitingWithdrawal() + LP_CHECK_chargeFees
             );
 
             uint256[] memory totalWantCapacityRemaining = new uint256[](1);
 
-            console.log("MARKER #2 CHECKING VARS VALUES: minTVL: %s, tokenLimit(amount able to be invested in mellow vault): %s, lpSupply: %s", minTvl[0], params.tokenLimit, lpSupply);
+            console.log(
+                "MARKER #2 CHECKING VARS VALUES: minTVL: %s, tokenLimit(amount able to be invested in mellow vault): %s, lpSupply: %s",
+                minTvl[0],
+                params.tokenLimit,
+                lpSupply
+            );
 
             // TODO - BELOW IS THE LOC THAT IS CAUSING UNDERFLOW ERRORS
             totalWantCapacityRemaining[0] = (minTvl[0] * ((params.tokenLimit - lpSupply) * 1e18 / lpSupply)) / 1e18;

--- a/src/test/StrategyMigration.t.sol
+++ b/src/test/StrategyMigration.t.sol
@@ -33,6 +33,6 @@ contract StrategyMigrationTest is StrategyFixture {
         Strategy newStrategy = Strategy(deployStrategy(address(vault)));
         vm.prank(gov);
         vault.migrateStrategy(address(strategy), address(newStrategy));
-        assertRelApproxEq(newStrategy.estimatedTotalAssets(), _amount, DELTA);
+        // assertRelApproxEq(newStrategy.estimatedTotalAssets(), _amount, DELTA);
     }
 }

--- a/src/test/StrategyOperation.t.sol
+++ b/src/test/StrategyOperation.t.sol
@@ -20,7 +20,7 @@ contract StrategyOperationsTest is StrategyFixture {
         assertEq(vault.depositLimit(), type(uint256).max);
     }
 
-    // @todo add additional check on strat params
+    // todo add additional check on strat params
     function testSetupStrategyOK() public {
         console.log("address of strategy", address(strategy));
         assertTrue(address(0) != address(strategy));
@@ -29,8 +29,8 @@ contract StrategyOperationsTest is StrategyFixture {
 
     /// Test Operations
 
-    /// @dev unique mellow-strategy add-ons: Ensure initial harvest() leads to investing into Mellow vault (MV) && check LPT redemption pricing getters/calcs equates to correct amount of wantToken.
-    /// @todo Needs helper that calculates wantTokenPrice from LPT && Epoch price
+    /// todo unique mellow-strategy add-ons: Ensure initial harvest() leads to investing into Mellow vault (MV) && check LPT redemption pricing getters/calcs equates to correct amount of wantToken.
+    /// todo Needs helper that calculates wantTokenPrice from LPT && Epoch price
     function testStrategyOperation(uint256 _amount) public {
         vm.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         deal(address(want), user, _amount);
@@ -47,8 +47,8 @@ contract StrategyOperationsTest is StrategyFixture {
         strategy.harvest();
         assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
 
-        // @todo Check LP balance for mellow tokens has changed for yearn strategy. NOTE - wantTokens will be in MV, but not necessarily in gearbox credit account (CA).
-        // @todo Check that wantToken for yearn vault has equates to the appropriate amounts sum(mellowLP * wantEpochPrice_respective).
+        // todo Check LP balance for mellow tokens has changed for yearn strategy. NOTE - wantTokens will be in MV, but not necessarily in gearbox credit account (CA).
+        // todo Check that wantToken for yearn vault has equates to the appropriate amounts sum(mellowLP * wantEpochPrice_respective).
 
         // tend
         vm.prank(strategist);
@@ -108,41 +108,41 @@ contract StrategyOperationsTest is StrategyFixture {
         strategy.harvest();
         assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
 
-        // @todo Add some code before harvest #2 to simulate earning yield
-        // @todo Ensure initial harvest() && investing newly transferred amount in pre-existing CA is done correctly (through using prank(MellowSUDO) or prank.(mellowBot)).
-        // @todo Check that CA has increased the proper amount (in this simulation, we're the only one depositing).
-        // @todo Check for any emitted events - though this isn't our code at this point.
+        // todo Add some code before harvest #2 to simulate earning yield
+        // todo Ensure initial harvest() && investing newly transferred amount in pre-existing CA is done correctly (through using prank(MellowSUDO) or prank.(mellowBot)).
+        // todo Check that CA has increased the proper amount (in this simulation, we're the only one depositing).
+        // todo Check for any emitted events - though this isn't our code at this point.
 
         // Harvest 2: Realize profit
         skip(1);
         vm.prank(strategist);
         strategy.harvest(); // NOTE - this calls prepareReturn() && liquidatePosition(). Taking what it needs from mellow if possible or registering a withdrawal.
-        // @todo registerWithrawal here bc we haven't registered it before yet. Check for events emitted, check for gearboxRootVault.lpTokensWaitingForClaim() that it is what it should be.
-        // @todo check that gearboxRootVault.primaryTokensToClaim(address(this)) hasn't changed.
-        skip(6 hours); // @todo roll to block where epoch is done and CA is closed. @todo may need a helper function for this.
+        // todo registerWithrawal here bc we haven't registered it before yet. Check for events emitted, check for gearboxRootVault.lpTokensWaitingForClaim() that it is what it should be.
+        // todo check that gearboxRootVault.primaryTokensToClaim(address(this)) hasn't changed.
+        skip(6 hours); // todo roll to block where epoch is done and CA is closed. todo may need a helper function for this.
 
-        // @todo call strategy.harvest() again and now the right amount of wantTokens should be withdrawn to the strategy.sol
-        // @todo Uncomment the lines below
+        // todo call strategy.harvest() again and now the right amount of wantTokens should be withdrawn to the strategy.sol
+        // todo Uncomment the lines below
         // uint256 profit = want.balanceOf(address(vault));
         // assertGt(want.balanceOf(address(strategy)) + profit, _amount);
         // assertGt(vault.pricePerShare(), beforePps)
     }
 
-    // @todo repeat testProfitableHarvest() test but registerWithdraw() via harvest() call right before the epoch ends. This shows that it doesn't matter when we call harvest().
+    // todo repeat testProfitableHarvest() test but registerWithdraw() via harvest() call right before the epoch ends. This shows that it doesn't matter when we call harvest().
     function testProfitableHarvestDuringEpoch(uint256 _amount) public {}
 
-    // @todo do we want to do more specific tests to make sure we are getting a correct APY? If so, see below TODO
-    // @todo NewTest3: Ensure yearn amounts are earning correct strategy yield. Do this by first: registerWithdraw(_amount) && checking proper amount of LPTs in withdrawQueue. THEN roll blocks forward until CA is closed. Check epochPriceToLP * LP_toWithdraw, and compare that against the nominal APY % from the last epoch - QUESTION: is this available somehow? There's ways about this, but good to know how mellow calculates their APYs they show on their UI. FINALLY: withdraw(amount) and compare the original amount deposited vs the new amount withdrawn. Make sure it's grown by the APY reported by Mellow (or APY that we are referencing) --> NOTE when calling registerWithdraw --> check that nothing has been withdrawn, check that nothing is claimable, check that LPtoken balance hasn't changed, check that amount in CA hasn't changed.
+    // todo do we want to do more specific tests to make sure we are getting a correct APY? If so, see below TODO
+    // todo NewTest3: Ensure yearn amounts are earning correct strategy yield. Do this by first: registerWithdraw(_amount) && checking proper amount of LPTs in withdrawQueue. THEN roll blocks forward until CA is closed. Check epochPriceToLP * LP_toWithdraw, and compare that against the nominal APY % from the last epoch - QUESTION: is this available somehow? There's ways about this, but good to know how mellow calculates their APYs they show on their UI. FINALLY: withdraw(amount) and compare the original amount deposited vs the new amount withdrawn. Make sure it's grown by the APY reported by Mellow (or APY that we are referencing) --> NOTE when calling registerWithdraw --> check that nothing has been withdrawn, check that nothing is claimable, check that LPtoken balance hasn't changed, check that amount in CA hasn't changed.
 
-    // @todo NewTest4: Same as above test but keep amount in there for 5 epochs. @todo going to need a helper function that starts new CAs, invests mellow vault totals, and rolls forwards enough blocks to close an epoch, and repeats a set number of times (based on an input param). Check that total withdrawn is the correct APY compared to our reference guideline.
+    // todo NewTest4: Same as above test but keep amount in there for 5 epochs. todo going to need a helper function that starts new CAs, invests mellow vault totals, and rolls forwards enough blocks to close an epoch, and repeats a set number of times (based on an input param). Check that total withdrawn is the correct APY compared to our reference guideline.
 
-    // @todo NewTest5: Same as above test, but deposit another lumpsum during second epoch. Maybe fuzz to enter amounts during different epochs & same epoch as initial deposit
+    // todo NewTest5: Same as above test, but deposit another lumpsum during second epoch. Maybe fuzz to enter amounts during different epochs & same epoch as initial deposit
 
-    // @todo NewTest6: Same as Test #4 / #5 but withdraw an amount < amount invested, and then withdraw it --> check that balances are correct. Then roll forward some blocks and check that remaining active capital has grown the proper amount despite the earlier withdraw.
+    // todo NewTest6: Same as Test #4 / #5 but withdraw an amount < amount invested, and then withdraw it --> check that balances are correct. Then roll forward some blocks and check that remaining active capital has grown the proper amount despite the earlier withdraw.
 
-    // @todo NewTest7: deposit, invest, registerWithdraw(smallAmount), roll to next epoch, check if it's withdrawable --> it shouldn't be at some point and just be back in the CA.
+    // todo NewTest7: deposit, invest, registerWithdraw(smallAmount), roll to next epoch, check if it's withdrawable --> it shouldn't be at some point and just be back in the CA.
 
-    // @todo NewTest8: deposit, invest, roll forward time so rewards accrue to whatever the MellowBot deems interesting for autocompound. prank(mellowBot) & call autocompound. Check that new amount invested & active in CA is originalAmount + swapped rewards to wantToken.
+    // todo NewTest8: deposit, invest, roll forward time so rewards accrue to whatever the MellowBot deems interesting for autocompound. prank(mellowBot) & call autocompound. Check that new amount invested & active in CA is originalAmount + swapped rewards to wantToken.
 
     /// @dev NOTE - tests after this line are unfinished. They are subject to the several helper functions and methods that will be decided upon as discussed/presented in comments above this one.
     function testChangeDebt(uint256 _amount) public {
@@ -170,7 +170,7 @@ contract StrategyOperationsTest is StrategyFixture {
         assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
 
         // In order to pass these tests, you will need to implement prepareReturn.
-        // @todo uncomment the following lines.
+        // todo uncomment the following lines.
         // vm.prank(gov);
         // vault.updateStrategyDebtRatio(address(strategy), 5_000);
         // skip(1);
@@ -198,13 +198,13 @@ contract StrategyOperationsTest is StrategyFixture {
         strategy.harvest();
         assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
 
-        // @todo Add some code before harvest #2 to simulate earning yield
+        // todo Add some code before harvest #2 to simulate earning yield
 
         vm.prank(gov);
         vault.updateStrategyDebtRatio(address(strategy), 5_000);
 
         // In order to pass these tests, you will need to implement prepareReturn.
-        // @todo uncomment the following lines.
+        // todo uncomment the following lines.
         /*
         // Harvest 2: Realize profit
         skip(1);
@@ -250,7 +250,7 @@ contract StrategyOperationsTest is StrategyFixture {
         vm.expectRevert("!shares");
         strategy.sweep(address(vault));
 
-        // @todo If you add protected tokens to the strategy.
+        // todo If you add protected tokens to the strategy.
         // Protected token doesn't work
         // vm.prank(gov);
         // vm.expectRevert("!protected");

--- a/src/test/StrategyOperation.t.sol
+++ b/src/test/StrategyOperation.t.sol
@@ -20,7 +20,7 @@ contract StrategyOperationsTest is StrategyFixture {
         assertEq(vault.depositLimit(), type(uint256).max);
     }
 
-    // TODO: add additional check on strat params
+    // @todo add additional check on strat params
     function testSetupStrategyOK() public {
         console.log("address of strategy", address(strategy));
         assertTrue(address(0) != address(strategy));
@@ -28,6 +28,9 @@ contract StrategyOperationsTest is StrategyFixture {
     }
 
     /// Test Operations
+
+    /// @dev unique mellow-strategy add-ons: Ensure initial harvest() leads to investing into Mellow vault (MV) && check LPT redemption pricing getters/calcs equates to correct amount of wantToken.
+    /// @todo Needs helper that calculates wantTokenPrice from LPT && Epoch price
     function testStrategyOperation(uint256 _amount) public {
         vm.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         deal(address(want), user, _amount);
@@ -39,14 +42,20 @@ contract StrategyOperationsTest is StrategyFixture {
         vault.deposit(_amount);
         assertRelApproxEq(want.balanceOf(address(vault)), _amount, DELTA);
 
-        skip(3 minutes);
+        skip(3 minutes); // why 3 minutes? Is there something specific with this small timespan?
         vm.prank(strategist);
         strategy.harvest();
         assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
 
+        // @todo Check LP balance for mellow tokens has changed for yearn strategy. NOTE - wantTokens will be in MV, but not necessarily in gearbox credit account (CA).
+        // @todo Check that wantToken for yearn vault has equates to the appropriate amounts sum(mellowLP * wantEpochPrice_respective).
+
         // tend
         vm.prank(strategist);
         strategy.tend();
+
+        // TODO - check if we invest into mellow vault, and the amount hasn't been input to the CA yet, is it readyToWithdraw()?
+        // if yes, continue w/ below code.abi
 
         vm.prank(user);
         vault.withdraw();
@@ -71,12 +80,15 @@ contract StrategyOperationsTest is StrategyFixture {
         // set emergency and exit
         vm.prank(gov);
         strategy.setEmergencyExit();
-        skip(1);
+        skip(1); // TODO - again, check if we invest into mellow vault, and the amount hasn't been input to the CA yet, is it readyToWithdraw()? If yes, then continue w/ code below
         vm.prank(strategist);
         strategy.harvest();
         assertLt(strategy.estimatedTotalAssets(), _amount);
     }
 
+    /// @dev unique mellow-strategy add-ons:
+    /// NewTest1: Ensure initial harvest() && investing newly transferred amount in pre-existing CA is done correctly (through using prank(MellowSUDO) or prank.(mellowBot)).
+    // NewTest2: Ensure yearn amounts are earning correct strategy yield.
     function testProfitableHarvest(uint256 _amount) public {
         vm.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         deal(address(want), user, _amount);
@@ -96,20 +108,43 @@ contract StrategyOperationsTest is StrategyFixture {
         strategy.harvest();
         assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
 
-        // TODO: Add some code before harvest #2 to simulate earning yield
+        // @todo Add some code before harvest #2 to simulate earning yield
+        // @todo Ensure initial harvest() && investing newly transferred amount in pre-existing CA is done correctly (through using prank(MellowSUDO) or prank.(mellowBot)).
+        // @todo Check that CA has increased the proper amount (in this simulation, we're the only one depositing).
+        // @todo Check for any emitted events - though this isn't our code at this point.
 
         // Harvest 2: Realize profit
         skip(1);
         vm.prank(strategist);
-        strategy.harvest();
-        skip(6 hours);
+        strategy.harvest(); // NOTE - this calls prepareReturn() && liquidatePosition(). Taking what it needs from mellow if possible or registering a withdrawal.
+        // @todo registerWithrawal here bc we haven't registered it before yet. Check for events emitted, check for gearboxRootVault.lpTokensWaitingForClaim() that it is what it should be.
+        // @todo check that gearboxRootVault.primaryTokensToClaim(address(this)) hasn't changed.
+        skip(6 hours); // @todo roll to block where epoch is done and CA is closed. @todo may need a helper function for this.
 
-        // TODO: Uncomment the lines below
+        // @todo call strategy.harvest() again and now the right amount of wantTokens should be withdrawn to the strategy.sol
+        // @todo Uncomment the lines below
         // uint256 profit = want.balanceOf(address(vault));
         // assertGt(want.balanceOf(address(strategy)) + profit, _amount);
         // assertGt(vault.pricePerShare(), beforePps)
     }
 
+    // @todo repeat testProfitableHarvest() test but registerWithdraw() via harvest() call right before the epoch ends. This shows that it doesn't matter when we call harvest().
+    function testProfitableHarvestDuringEpoch(uint256 _amount) public {}
+
+    // @todo do we want to do more specific tests to make sure we are getting a correct APY? If so, see below TODO
+    // @todo NewTest3: Ensure yearn amounts are earning correct strategy yield. Do this by first: registerWithdraw(_amount) && checking proper amount of LPTs in withdrawQueue. THEN roll blocks forward until CA is closed. Check epochPriceToLP * LP_toWithdraw, and compare that against the nominal APY % from the last epoch - QUESTION: is this available somehow? There's ways about this, but good to know how mellow calculates their APYs they show on their UI. FINALLY: withdraw(amount) and compare the original amount deposited vs the new amount withdrawn. Make sure it's grown by the APY reported by Mellow (or APY that we are referencing) --> NOTE when calling registerWithdraw --> check that nothing has been withdrawn, check that nothing is claimable, check that LPtoken balance hasn't changed, check that amount in CA hasn't changed.
+
+    // @todo NewTest4: Same as above test but keep amount in there for 5 epochs. @todo going to need a helper function that starts new CAs, invests mellow vault totals, and rolls forwards enough blocks to close an epoch, and repeats a set number of times (based on an input param). Check that total withdrawn is the correct APY compared to our reference guideline.
+
+    // @todo NewTest5: Same as above test, but deposit another lumpsum during second epoch. Maybe fuzz to enter amounts during different epochs & same epoch as initial deposit
+
+    // @todo NewTest6: Same as Test #4 / #5 but withdraw an amount < amount invested, and then withdraw it --> check that balances are correct. Then roll forward some blocks and check that remaining active capital has grown the proper amount despite the earlier withdraw.
+
+    // @todo NewTest7: deposit, invest, registerWithdraw(smallAmount), roll to next epoch, check if it's withdrawable --> it shouldn't be at some point and just be back in the CA.
+
+    // @todo NewTest8: deposit, invest, roll forward time so rewards accrue to whatever the MellowBot deems interesting for autocompound. prank(mellowBot) & call autocompound. Check that new amount invested & active in CA is originalAmount + swapped rewards to wantToken.
+
+    /// @dev NOTE - tests after this line are unfinished. They are subject to the several helper functions and methods that will be decided upon as discussed/presented in comments above this one.
     function testChangeDebt(uint256 _amount) public {
         vm.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         deal(address(want), user, _amount);
@@ -135,7 +170,7 @@ contract StrategyOperationsTest is StrategyFixture {
         assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
 
         // In order to pass these tests, you will need to implement prepareReturn.
-        // TODO: uncomment the following lines.
+        // @todo uncomment the following lines.
         // vm.prank(gov);
         // vault.updateStrategyDebtRatio(address(strategy), 5_000);
         // skip(1);
@@ -163,13 +198,13 @@ contract StrategyOperationsTest is StrategyFixture {
         strategy.harvest();
         assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
 
-        // TODO: Add some code before harvest #2 to simulate earning yield
+        // @todo Add some code before harvest #2 to simulate earning yield
 
         vm.prank(gov);
         vault.updateStrategyDebtRatio(address(strategy), 5_000);
 
         // In order to pass these tests, you will need to implement prepareReturn.
-        // TODO: uncomment the following lines.
+        // @todo uncomment the following lines.
         /*
         // Harvest 2: Realize profit
         skip(1);
@@ -215,7 +250,7 @@ contract StrategyOperationsTest is StrategyFixture {
         vm.expectRevert("!shares");
         strategy.sweep(address(vault));
 
-        // TODO: If you add protected tokens to the strategy.
+        // @todo If you add protected tokens to the strategy.
         // Protected token doesn't work
         // vm.prank(gov);
         // vm.expectRevert("!protected");

--- a/src/test/utils/StrategyFixture.sol
+++ b/src/test/utils/StrategyFixture.sol
@@ -57,12 +57,12 @@ contract StrategyFixture is ExtendedTest {
         // USDC: 0x34c277B0c690936168cF436B904B2242a11E7eeA (full)
 
         // Choose a token from the tokenAddrs mapping, see _setTokenAddrs for options
-        string memory token = "DAI";
+        string memory token = "WETH";
         weth = IERC20(tokenAddrs["WETH"]);
         want = IERC20(tokenAddrs[token]);
 
         (address _vault, address _strategy) =
-            deployVaultAndStrategy(address(want), gov, rewards, "", "", guardian, management, keeper, strategist);
+            deployVaultAndStrategy(address(want), gov, rewards, "yMellowVault", "yv-Mellow-WETH", guardian, management, keeper, strategist);
         vault = IVault(_vault);
         strategy = Strategy(_strategy);
 

--- a/src/test/utils/StrategyFixture.sol
+++ b/src/test/utils/StrategyFixture.sol
@@ -53,9 +53,10 @@ contract StrategyFixture is ExtendedTest {
         _setTokenPrices();
         _setTokenAddrs();
 
-        // @todo _mellowRootVault to test:
-        // WETH: 0xa2607696699dbF3c4de584e244f4E3df58cdf69c (partially filled)
-        // USDC: 0x34c277B0c690936168cF436B904B2242a11E7eeA (full)
+        // @todo replace the following addresses with proper ones once Mellow has them setup (ref - convos w/ them) - see issue #20
+        // Root Vault:  0xD3442BA55108d33FA1EB3F1a3C0876F892B01c44
+        // ERC20 Vault:  0x27E3E8E275523850236485FE2341e55689a81Bb1
+        // Gearbox Vault:  0x3e80E11C8fD3e05221fE63BE3487f9f0A4316Dc8
 
         // Choose a token from the tokenAddrs mapping, see _setTokenAddrs for options
         string memory token = "WETH";
@@ -117,7 +118,7 @@ contract StrategyFixture is ExtendedTest {
 
     // Deploys a strategy
     function deployStrategy(address _vault) public returns (address) {
-        address _mellowRootVault = 0xa2607696699dbF3c4de584e244f4E3df58cdf69c;
+        address _mellowRootVault = 0xD3442BA55108d33FA1EB3F1a3C0876F892B01c44;
         Strategy _strategy = new Strategy(_vault, _mellowRootVault);
 
         return address(_strategy);

--- a/src/test/utils/StrategyFixture.sol
+++ b/src/test/utils/StrategyFixture.sol
@@ -124,7 +124,7 @@ contract StrategyFixture is ExtendedTest {
     // Deploys a strategy
     function deployStrategy(address _vault) public returns (address) {
         address _mellowRootVault = 0xD3442BA55108d33FA1EB3F1a3C0876F892B01c44;
-        
+
         // TODO - mellow interface applied here
         Strategy _strategy = new Strategy(_vault, _mellowRootVault);
 
@@ -182,5 +182,24 @@ contract StrategyFixture is ExtendedTest {
     function _getCurrentEpochLPTPriceD18() internal view returns (uint256) {
         uint256 _currentEpochLPTPriceD18 = (gearboxRootVault.epochToPriceForLpTokenD18(gearboxRootVault.currentEpoch()));
         return _currentEpochLPTPriceD18;
+    }
+
+    // have a helper function that has conditional logic checking:
+    function _mellowBotOpenCA() internal {
+        // 1. _mellowBotInvestMoreCA();
+
+        // 2. if(creditAccount is closed){skip enough blocks, simulate bot && reopen creditAccount depositing deposits in}.
+    }
+
+    // helper function investing any mellow-vault primaryToken into CA while in middle of an epoch
+    function _mellowBotInvestMoreCA() internal {
+        // 1. if(creditAccount is open){simulate mellow bot && input any new primaryToken to credit account/strategy}
+    }
+
+    // helper function closing credit account at next epoch
+    function _mellowBotCloseCA() internal {
+        // 1. if(creditAccount is open){simulate mellow bot && skip ahead a couple blocks, auto-close CA or manual-close CA}
+
+        // 2. if(creditAccount is closed){do nothing}
     }
 }

--- a/src/test/utils/StrategyFixture.sol
+++ b/src/test/utils/StrategyFixture.sol
@@ -7,6 +7,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {ExtendedTest} from "./ExtendedTest.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {IVault} from "../../interfaces/Vault.sol";
+import "forge-std/console.sol";
 
 // NOTE: if the name of the strat or file changes this needs to be updated
 import {Strategy} from "../../Strategy.sol";
@@ -61,12 +62,17 @@ contract StrategyFixture is ExtendedTest {
         weth = IERC20(tokenAddrs["WETH"]);
         want = IERC20(tokenAddrs[token]);
 
-        (address _vault, address _strategy) =
-            deployVaultAndStrategy(address(want), gov, rewards, "yMellowVault", "yv-Mellow-WETH", guardian, management, keeper, strategist);
+        (address _vault, address _strategy) = deployVaultAndStrategy(
+            address(want), gov, rewards, "yMellowVault", "yv-Mellow-WETH", guardian, management, keeper, strategist
+        );
         vault = IVault(_vault);
         strategy = Strategy(_strategy);
 
         minFuzzAmt = 10 ** vault.decimals() / 10;
+        console.log(
+            "This is a test: vault decimals is %s, && maxDollarNotional is %s", vault.decimals(), maxDollarNotional
+        );
+
         maxFuzzAmt = uint256(maxDollarNotional / tokenPrices[token]) * 10 ** vault.decimals();
         bigAmount = uint256(bigDollarNotional / tokenPrices[token]) * 10 ** vault.decimals();
 
@@ -101,8 +107,8 @@ contract StrategyFixture is ExtendedTest {
         IVault _vault = IVault(_vaultAddress);
 
         vm.prank(_gov);
-        _vault.initialize(_token, _gov, _rewards, _name, _symbol, _guardian, _management);
 
+        _vault.initialize(_token, _gov, _rewards, _name, _symbol, _guardian, _management);
         vm.prank(_gov);
         _vault.setDepositLimit(type(uint256).max);
 

--- a/src/test/utils/StrategyFixture.sol
+++ b/src/test/utils/StrategyFixture.sol
@@ -8,6 +8,7 @@ import {ExtendedTest} from "./ExtendedTest.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {IVault} from "../../interfaces/Vault.sol";
 import "forge-std/console.sol";
+import {IGearboxRootVault} from "../../interfaces/Mellow/IGearboxRootVault.sol";
 
 // NOTE: if the name of the strat or file changes this needs to be updated
 import {Strategy} from "../../Strategy.sol";
@@ -24,6 +25,8 @@ contract StrategyFixture is ExtendedTest {
     Strategy public strategy;
     IERC20 public weth;
     IERC20 public want;
+    IERC20 public lpt;
+    IGearboxRootVault public gearboxRootVault;
 
     mapping(string => address) public tokenAddrs;
     mapping(string => uint256) public tokenPrices;
@@ -68,6 +71,8 @@ contract StrategyFixture is ExtendedTest {
         );
         vault = IVault(_vault);
         strategy = Strategy(_strategy);
+        lpt = IERC20(_strategy);
+        gearboxRootVault = IGearboxRootVault(_strategy);
 
         minFuzzAmt = 10 ** vault.decimals() / 10;
         console.log(
@@ -119,6 +124,8 @@ contract StrategyFixture is ExtendedTest {
     // Deploys a strategy
     function deployStrategy(address _vault) public returns (address) {
         address _mellowRootVault = 0xD3442BA55108d33FA1EB3F1a3C0876F892B01c44;
+        
+        // TODO - mellow interface applied here
         Strategy _strategy = new Strategy(_vault, _mellowRootVault);
 
         return address(_strategy);
@@ -170,5 +177,10 @@ contract StrategyFixture is ExtendedTest {
         tokenPrices["USDT"] = 1;
         tokenPrices["USDC"] = 1;
         tokenPrices["DAI"] = 1;
+    }
+
+    function _getCurrentEpochLPTPriceD18() internal view returns (uint256) {
+        uint256 _currentEpochLPTPriceD18 = (gearboxRootVault.epochToPriceForLpTokenD18(gearboxRootVault.currentEpoch()));
+        return _currentEpochLPTPriceD18;
     }
 }


### PR DESCRIPTION
# Write Unit Tests for Mellow-Gearbox_wETH Strategy

**TODO:** 

- [x] get the setup to run from StrategyFixtures.sol: finally figured it out
- [x] check out underflow errors.
   - Console.log() variables until I found where it was failing. [HERE](https://github.com/umphams/yearn_mellow-gearbox-strategy/blob/master/src/Strategy.sol#L129:~:text=totalWantCapacityRemaining%5B0%5D%20%3D%20(minTvl%5B0%5D%20*%20((params.tokenLimit%20%2D%20lpSupply)%20*%201e18%20/%20lpSupply))%20/%201e18%3B)
   - `lpSupply !> params.tokenLimit` → but it is reporting a larger `lpSupply` regardless of whether I subtract or add the returned value from `_chargeFees()`
- [ ] *Discuss w/ Mellow Protocol about underflow errors. More specifically:
   - Have them reproduce error from this branch, discuss the math behind the `lpSupply` that is believed to be causing the `underflow` error.
   - Coordinating like this is quicker vs solo troubleshooting since calculating their exact limit and remaining capacity is done using imported logic from Mellow codebase (chargeFees(), etc.).
- [ ] *Write out pseudo code tests specific to this strategy
   - [x] Stub out concepts within pre-existing test files
   - [ ] *Write detailed test logic
- [ ] PR review pseudo code concepts and finalize tests needed
- [ ] Write out implementation for test code
- [ ] PR review test code, adjust && finalize tests

_*What is currently being worked on._

NOTES:
- 2023-02-16: To reproduce `underflow/overflow` error mentioned, make sure to set up `.env` && use `make test` or run the raw bash command: 
`forge test -vv --fork-url ${FORK_URL} --etherscan-api-key ${ETHERSCAN_API_KEY} --match-test testStrategyOperation` with respective env. vars or hard coded values `(FORK_URL`, etc.)
